### PR TITLE
Added 2 tests for CD servers: DefaultDefinitionDatabase + ListManagement

### DIFF
--- a/src/Sitecore.DiagnosticsTool.Tests.UnitTests/ECM/DefaultDefinitionDatabaseTests.cs
+++ b/src/Sitecore.DiagnosticsTool.Tests.UnitTests/ECM/DefaultDefinitionDatabaseTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Xml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Sitecore.Diagnostics.Objects;
+using Sitecore.DiagnosticsTool.Core.Categories;
+using Sitecore.DiagnosticsTool.TestRunner;
+using Sitecore.DiagnosticsTool.TestRunner.Base;
+using Sitecore.DiagnosticsTool.Tests.ECM;
+using Sitecore.DiagnosticsTool.Tests.UnitTestsHelper;
+using Sitecore.DiagnosticsTool.Tests.UnitTestsHelper.Context;
+using Sitecore.DiagnosticsTool.Tests.UnitTestsHelper.Resources;
+using Xunit;
+
+namespace Sitecore.DiagnosticsTool.Tests.UnitTests.ECM
+{
+    [TestClass]
+    public class DefaultDefinitionDatabaseTests : DefaultDefinitionDatabase
+    {
+        [Fact]
+        public void TestPassed()
+        {
+            var sitecoreConfiguration = new SitecoreInstance
+            {
+                ServerRoles = new[] { ServerRole.ContentDelivery },
+                Configuration = new XmlDocument().Create("/configuration/sitecore/settings/setting[@name='Analytics.DefaultDefinitionDatabase' and @value='web']"),
+                Version = new SitecoreVersion(8, 2, 3, 170407)
+            };
+
+            UnitTestContext
+                .Create(this)
+                .AddResource(sitecoreConfiguration)
+                .Process(this)
+                .Done();
+
+        }
+
+        [Fact]
+        public void TestFailed()
+        {
+            var sitecoreConfiguration = new SitecoreInstance
+            {
+                ServerRoles = new[] { ServerRole.ContentDelivery },
+                Configuration = new XmlDocument().Create("/configuration/sitecore/settings/setting[@name='Analytics.DefaultDefinitionDatabase' and @value='master']"),
+                Version = new SitecoreVersion(8, 2, 3, 170407)
+            };
+
+            UnitTestContext
+                .Create(this)
+                .AddResource(sitecoreConfiguration)
+                .Process(this)
+                .MustReturn(new TestOutput(TestResultState.Warning, ErrorMessage))
+                .Done();
+        }
+    }
+}

--- a/src/Sitecore.DiagnosticsTool.Tests/ECM/DefaultDefinitionDatabase.cs
+++ b/src/Sitecore.DiagnosticsTool.Tests/ECM/DefaultDefinitionDatabase.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Sitecore.Diagnostics.Base;
+using Sitecore.Diagnostics.Objects;
+using Sitecore.DiagnosticsTool.Core.Categories;
+using Sitecore.DiagnosticsTool.Core.Tests;
+using Sitecore.DiagnosticsTool.Tests.ECM.Helpers;
+
+namespace Sitecore.DiagnosticsTool.Tests.ECM
+{
+    public class DefaultDefinitionDatabase : Test
+    {
+        public override string Name => "Default Definition Database should be switched to 'web' on CD servers";
+
+        public override IEnumerable<Category> Categories => new[] { Category.Ecm };
+        public override IEnumerable<ServerRole> ServerRoles => new[] { ServerRole.ContentDelivery };
+
+        public override bool IsActual(IReadOnlyCollection<ServerRole> roles, ISitecoreVersion sitecoreVersion, ITestResourceContext data)
+        {
+            return sitecoreVersion.Major >= 8 && ServerRoles.Intersect(roles).Any();
+        }
+
+        [NotNull]
+        protected string ErrorMessage => "'web' database should be marked as a Default Definition Database on CD.";
+
+        public override void Process(ITestResourceContext data, ITestOutputContext output)
+        {
+            Assert.ArgumentNotNull(data, nameof(data));
+
+            if (data.SitecoreInfo.GetSetting("Analytics.DefaultDefinitionDatabase") != "web")
+            {
+                output.Warning(ErrorMessage);
+            }
+        }
+    }
+}

--- a/src/Sitecore.DiagnosticsTool.Tests/ECM/ListManagement.cs
+++ b/src/Sitecore.DiagnosticsTool.Tests/ECM/ListManagement.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Sitecore.Diagnostics.Base;
+using Sitecore.Diagnostics.Objects;
+using Sitecore.DiagnosticsTool.Core.Categories;
+using Sitecore.DiagnosticsTool.Core.Output;
+using Sitecore.DiagnosticsTool.Core.Tests;
+using Sitecore.DiagnosticsTool.Tests.General.Health;
+
+namespace Sitecore.DiagnosticsTool.Tests.ECM
+{
+    public class ListManagement : Test
+    {
+        public override IEnumerable<Category> Categories => new[] { Category.Ecm };
+
+        public override string Name => "ListManagement disabled on CD";
+
+        public override IEnumerable<ServerRole> ServerRoles => new[] { ServerRole.ContentDelivery };
+
+        public override bool IsActual(IReadOnlyCollection<ServerRole> roles, ISitecoreVersion sitecoreVersion, ITestResourceContext data)
+        {
+            return sitecoreVersion.Major>=8 && ServerRoles.Intersect(roles).Any();
+        }
+
+        public override void Process(ITestResourceContext data, ITestOutputContext output)
+        {
+            IList<string> filesToBeDisabled=new List<string>();
+            Assert.ArgumentNotNull(data, nameof(data));
+            foreach (var filePath in data.SitecoreInfo.IncludeFiles.Keys)
+            {
+                if (filePath.Contains("Sitecore.Listmanagement"))
+                {
+                    filesToBeDisabled.Add(filePath);
+                }
+            }
+            if (filesToBeDisabled.Count>0)
+            {
+             output.Error(ErrorMessage(filesToBeDisabled));   
+            }
+            
+        }
+
+        private ShortMessage ErrorMessage(IList<string> filesToBeDisabled)
+        {
+            return "Files in App_Cofig\\Include\\ListManagement\\ folder should be disabled.";
+        }
+    }
+}


### PR DESCRIPTION
UnitTest is designed for DefaultDefinitionDatabase only.

ListManagement requires filling of the Sitecore.Info.IncludeFiles collection.