### PR TITLE
Implement test to check DefaultDatabaseDefinition setting on CD server

### DIFF
--- a/src/Sitecore.DiagnosticsTool.Tests.UnitTests/ECM/DefaultDatabaseDefinitionTests.cs
+++ b/src/Sitecore.DiagnosticsTool.Tests.UnitTests/ECM/DefaultDatabaseDefinitionTests.cs
@@ -1,0 +1,68 @@
+﻿namespace Sitecore.DiagnosticsTool.Tests.UnitTests.ECM
+{
+  using System.Xml;
+
+  using Sitecore.Diagnostics.Objects;
+  using Sitecore.DiagnosticsTool.Core.Categories;
+  using Sitecore.DiagnosticsTool.TestRunner;
+  using Sitecore.DiagnosticsTool.TestRunner.Base;
+  using Sitecore.DiagnosticsTool.Tests.ECM;
+  using Sitecore.DiagnosticsTool.Tests.UnitTestsHelper;
+  using Sitecore.DiagnosticsTool.Tests.UnitTestsHelper.Context;
+  using Sitecore.DiagnosticsTool.Tests.UnitTestsHelper.Resources;
+  using Sitecore.Diagnostics.InfoService.Client;
+  using Sitecore.DiagnosticsTool.Core.Collections;
+  using Sitecore.DiagnosticsTool.Core.Resources.SitecoreInformation;
+  using Sitecore.DiagnosticsTool.DataProviders.SupportPackage.Resources.SitecoreInformation;
+
+  using Xunit;
+  using Diagnostics.InfoService.Client.Builder;
+
+  public class DefaultDefinitionDatabaseTests : DefaultDefinitionDatabase
+  {
+    [Fact]
+    public void TestPassed()
+    {
+      var sitecoreConfiguration = new SitecoreInstance
+      {
+        InstanceName="cd1",
+        ServerRoles = new[] { ServerRole.ContentDelivery },
+        Configuration = new XmlDocument().Create("/configuration/sitecore/settings/setting[@name='Analytics.DefaultDefinitionDatabase' and @value='web']"),
+        Version = new SitecoreVersion(8, 2, 3),
+        InstalledModules = new Map<IReleaseInfo>(x => x.Release.ProductName)
+        {
+        { new ReleaseInfo(ServiceClientBuilder.Create().Build().Products["Email Experience Manager"].Versions["3.4.1"]) }
+      },
+      };
+      new SolutionUnitTestContext()
+
+        .AddInstance(sitecoreConfiguration)
+        .Process(this)
+        .Done();
+     
+    }
+
+    [Fact]
+    public void TestFailed()
+    {
+      var sitecoreConfiguration = new SitecoreInstance
+      {
+        InstanceName = "cd1",
+        ServerRoles = new[] { ServerRole.ContentDelivery },
+        Configuration = new XmlDocument().Create("/configuration/sitecore/settings"), //no setting means "master" database is used.
+        Version = new SitecoreVersion(8, 2, 2),
+        InstalledModules = new Map<IReleaseInfo>(x => x.Release.ProductName)
+        {
+          { new ReleaseInfo(ServiceClientBuilder.Create().Build().Products["Email Experience Manager"].Versions["3.4.1"]) }
+        },
+      };
+
+      new SolutionUnitTestContext()
+
+        .AddInstance(sitecoreConfiguration)
+        .Process(this)
+        .MustReturn(new TestOutput(TestResultState.Warning, ErrorMessage))
+        .Done();
+    }
+  }
+}

--- a/src/Sitecore.DiagnosticsTool.Tests.UnitTests/SDT.Tests.UnitTests.csproj
+++ b/src/Sitecore.DiagnosticsTool.Tests.UnitTests/SDT.Tests.UnitTests.csproj
@@ -121,6 +121,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="ECM\DefaultDatabaseDefinitionTests.cs" />
     <Compile Include="ECM\ExmSpeakHandlerCheckerTests.cs" />
     <Compile Include="ECM\RendererUrlSettingTests.cs" />
     <Compile Include="General\Performance\CompilationDebugDisabledTests.cs" />

--- a/src/Sitecore.DiagnosticsTool.Tests/ECM/DefaultDefinitionDatabase.cs
+++ b/src/Sitecore.DiagnosticsTool.Tests/ECM/DefaultDefinitionDatabase.cs
@@ -1,0 +1,50 @@
+﻿namespace Sitecore.DiagnosticsTool.Tests.ECM
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+  using System.Text;
+  using System.Threading.Tasks;
+
+  using JetBrains.Annotations;
+
+  using Sitecore.Diagnostics.Base;
+  using Sitecore.Diagnostics.Objects;
+  using Sitecore.DiagnosticsTool.Core.Categories;
+  using Sitecore.DiagnosticsTool.Core.Tests;
+  using Sitecore.DiagnosticsTool.Tests.ECM.Helpers;
+
+  public class DefaultDefinitionDatabase : Test
+  {
+    public override string Name => "Default Definition Database should be switched to 'web' on CD servers";
+
+    public override IEnumerable<Category> Categories => new[] { Category.Ecm };
+
+    protected override bool IsActual(ISitecoreVersion sitecoreVersion)
+    {
+      return sitecoreVersion.Major >= 8;
+    }
+
+    protected override bool IsActual(IReadOnlyCollection<ServerRole> roles)
+    {
+      return roles.Contains(ServerRole.ContentDelivery);
+    }
+    protected override bool IsActual(IInstanceResourceContext data)
+    {
+      return data.SitecoreInfo.ModulesInformation.InstalledModules.ContainsKey("Email Experience Manager");
+    }
+
+    [NotNull]
+    protected string ErrorMessage => "Analytics.DefaultDefinitionDatabase setting should be defined on CD server. 'web' should be used as a value.";
+
+    public override void Process(IInstanceResourceContext data, ITestOutputContext output)
+    {
+      Assert.ArgumentNotNull(data, nameof(data));
+
+      if (data.SitecoreInfo.GetSetting("Analytics.DefaultDefinitionDatabase") != "web")
+      {
+        output.Warning(ErrorMessage);
+      }
+    }
+  }
+}

--- a/src/Sitecore.DiagnosticsTool.Tests/SDT.Tests.csproj
+++ b/src/Sitecore.DiagnosticsTool.Tests/SDT.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -90,6 +90,7 @@
     <Compile Include="Analytics\EmailReportsTaskFailsWithoutMasterDatabase.cs" />
     <Compile Include="Analytics\MaxMindNotSupported.cs" />
     <Compile Include="Debug\ChangedSettings.cs" />
+    <Compile Include="ECM\DefaultDefinitionDatabase.cs" />
     <Compile Include="ECM\ExMSpeakHandlerChecker.cs" />
     <Compile Include="General\Performance\AbstractQueueSizeTest.cs" />
     <Compile Include="General\Performance\CheckIndexFragmentation.cs" />


### PR DESCRIPTION
The test idea comes from the original DiagToolset Tests spreadsheet. I believe those tests don't require approval.
[Copy of ECM DiagToolset Tests.xlsx](https://github.com/Sitecore/Sitecore-Diagnostics-Tool/files/1635654/Copy.of.ECM.DiagToolset.Tests.xlsx)
