### PR TITLE
Implement test to check ListManager configuration is disabled on CD

### DIFF
--- a/src/Sitecore.DiagnosticsTool.Tests.UnitTests/ECM/ListManagementTests.cs
+++ b/src/Sitecore.DiagnosticsTool.Tests.UnitTests/ECM/ListManagementTests.cs
@@ -1,0 +1,99 @@
+﻿namespace Sitecore.DiagnosticsTool.Tests.UnitTests.ECM
+{
+  using System.Collections.Generic;
+  using System.Xml;
+
+  using TestRunner;
+  using Core.Categories;
+  using UnitTestsHelper.Context;
+  using Sitecore.Diagnostics.Objects;
+  using Sitecore.DiagnosticsTool.Tests.ECM;
+  using Sitecore.DiagnosticsTool.Core.Collections;
+  using Sitecore.DiagnosticsTool.Core.Resources.Configuration;
+  using Sitecore.DiagnosticsTool.TestRunner.Base;
+  using Sitecore.DiagnosticsTool.Tests.UnitTestsHelper;
+  using Sitecore.DiagnosticsTool.Tests.UnitTestsHelper.Resources;
+  using Sitecore.Diagnostics.InfoService.Client.Builder;
+  using Sitecore.DiagnosticsTool.Core.Resources.SitecoreInformation;
+  using Sitecore.DiagnosticsTool.DataProviders.SupportPackage.Resources.SitecoreInformation;
+
+  using Xunit;
+
+  public class ListManagementTests : ListManagement
+  {
+    [Fact]
+    public void TestFailed()
+    {
+      var sitecoreConfiguration = new SitecoreInstance
+      {
+        InstanceName = "cd1",
+        ServerRoles = new[] { ServerRole.ContentDelivery },
+        Version = new SitecoreVersion(8, 2, 2),
+        Configuration = new XmlDocument(),
+        IncludeFiles = new Map<ConfigurationFile>(x => x.FilePath)
+          {
+            {
+              new ConfigurationFile("App_Config/Include/ListManagement/Sitecore.ListManagement.config",
+                "<configuration><sitecore></sitecore></configuration>")
+            },
+            {
+              new ConfigurationFile("App_Config/Include/ListManagement/Sitecore.ListManagement.Services.config",
+                "<configuration><sitecore></sitecore></configuration>")
+            },
+          },
+        InstalledModules = new Map<IReleaseInfo>(x => x.Release.ProductName)
+      {
+                   { new ReleaseInfo(ServiceClientBuilder.Create().Build().Products["Email Experience Manager"].Versions["3.4.1"]) }
+         },
+      };
+
+
+      new SolutionUnitTestContext()
+        .AddInstance(sitecoreConfiguration)
+        .Process(this)
+        .MustReturn(new TestOutput(TestResultState.Warning, ErrorMessage(),
+        data: GetMessage(
+          new List<string>()
+          {
+            "App_Config/Include/ListManagement/Sitecore.ListManagement.config",
+            "App_Config/Include/ListManagement/Sitecore.ListManagement.Services.config"
+          })))
+        .Done();
+    }
+
+    [Fact]
+    public void TestPassed()
+    {
+      var sitecoreConfiguration = new SitecoreInstance
+      {
+        InstanceName = "cd1",
+        ServerRoles = new[] { ServerRole.ContentDelivery },
+        Version = new SitecoreVersion(8, 2, 2),
+        Configuration = new XmlDocument()
+          .Create(
+            "/configuration/sitecore/"),
+        IncludeFiles = new Map<ConfigurationFile>(x => x.FilePath)
+        {
+          {
+            new ConfigurationFile("App_Config/Include/ListManagement/Sitecore.Helpers.config",
+              "<configuration><sitecore></sitecore></configuration>")
+          },
+          {
+            new ConfigurationFile("App_Config/Include/ListManagement/Sitecore.Services.config",
+              "<configuration><sitecore></sitecore></configuration>")
+          },
+        },
+        InstalledModules = new Map<IReleaseInfo>(x => x.Release.ProductName)
+      {
+        { new ReleaseInfo(ServiceClientBuilder.Create().Build().Products["Email Experience Manager"].Versions["3.4.1"]) }
+      },
+      };
+
+      new SolutionUnitTestContext()
+
+        .AddInstance(sitecoreConfiguration)
+        .Process(this)
+        .Done();
+    }
+  }
+}

--- a/src/Sitecore.DiagnosticsTool.Tests.UnitTests/SDT.Tests.UnitTests.csproj
+++ b/src/Sitecore.DiagnosticsTool.Tests.UnitTests/SDT.Tests.UnitTests.csproj
@@ -122,6 +122,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="ECM\ExmSpeakHandlerCheckerTests.cs" />
+    <Compile Include="ECM\ListManagementTests.cs" />
     <Compile Include="ECM\RendererUrlSettingTests.cs" />
     <Compile Include="General\Performance\CompilationDebugDisabledTests.cs" />
     <Compile Include="Search\ContentSearchUpdateStrategiesTests.cs" />

--- a/src/Sitecore.DiagnosticsTool.Tests/ECM/ListManagement.cs
+++ b/src/Sitecore.DiagnosticsTool.Tests/ECM/ListManagement.cs
@@ -1,0 +1,68 @@
+﻿namespace Sitecore.DiagnosticsTool.Tests.ECM
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+  using System.Text;
+  using System.Threading.Tasks;
+
+  using Sitecore.Diagnostics.Base;
+  using Sitecore.Diagnostics.Objects;
+  using Sitecore.DiagnosticsTool.Core.Categories;
+  using Sitecore.DiagnosticsTool.Core.Output;
+  using Sitecore.DiagnosticsTool.Core.Tests;
+  using Sitecore.DiagnosticsTool.Tests.General.Health;
+  using Sitecore.DiagnosticsTool.Core.Collections;
+
+  public class ListManagement : Test
+  {
+    public override IEnumerable<Category> Categories => new[] { Category.Ecm };
+    public override void Process(IInstanceResourceContext data, ITestOutputContext output)
+    {
+      IList<string> filesToBeDisabled = new List<string>();
+      Assert.ArgumentNotNull(data, nameof(data));
+      foreach (var filePath in data.SitecoreInfo.IncludeFiles.Keys)
+      {
+        if (filePath.StartsWith("\\App_Config\\Include\\ListManagement\\",StringComparison.InvariantCultureIgnoreCase)&&filePath.Contains("Sitecore.ListManagement"))
+        {
+          filesToBeDisabled.Add(filePath);
+        }
+      }
+      if (filesToBeDisabled.Count > 0)
+      {
+        output.Warning(ErrorMessage(),
+          detailed: GetMessage(filesToBeDisabled));
+      }
+    }
+
+    public override string Name => "ListManagement is disabled on CD";
+
+
+    protected override bool IsActual(ISitecoreVersion sitecoreVersion)
+    {
+      return sitecoreVersion.Major >= 8;
+    }
+    protected override bool IsActual(IReadOnlyCollection<ServerRole> roles)
+    {
+      return roles.Contains(ServerRole.ContentDelivery);
+    }
+
+    protected ShortMessage ErrorMessage()
+    {
+      return "One or several files in App_Cofig\\Include\\ListManagement\\ folder should be disabled ";
+    }
+    protected DetailedMessage GetMessage(IList<string> filesToBeDisabled)
+    {
+      var rows = filesToBeDisabled.Select(d =>
+          new TableRow(
+            new Pair("File", $"{d}"),
+            new Pair("Comment", "Should be disabled")))
+          .ToArray();
+
+      var message = new DetailedMessage(
+        new Table(rows));
+
+      return message;
+    }
+  }
+}

--- a/src/Sitecore.DiagnosticsTool.Tests/ECM/ListManagement.cs
+++ b/src/Sitecore.DiagnosticsTool.Tests/ECM/ListManagement.cs
@@ -40,7 +40,7 @@
 
     protected override bool IsActual(ISitecoreVersion sitecoreVersion)
     {
-      return sitecoreVersion.Major >= 8;
+      return sitecoreVersion.Major == 8;
     }
     protected override bool IsActual(IReadOnlyCollection<ServerRole> roles)
     {

--- a/src/Sitecore.DiagnosticsTool.Tests/SDT.Tests.csproj
+++ b/src/Sitecore.DiagnosticsTool.Tests/SDT.Tests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Analytics\MaxMindNotSupported.cs" />
     <Compile Include="Debug\ChangedSettings.cs" />
     <Compile Include="ECM\ExMSpeakHandlerChecker.cs" />
+    <Compile Include="ECM\ListManagement.cs" />
     <Compile Include="General\Performance\AbstractQueueSizeTest.cs" />
     <Compile Include="General\Performance\CheckIndexFragmentation.cs" />
     <Compile Include="Analytics\SessionTimeoutWhenSavingRichTextFields.cs" />


### PR DESCRIPTION
The test idea comes from the original DiagToolset Tests spreadsheet. I believe those tests don't require approval.
[Copy of ECM DiagToolset Tests.xlsx](https://github.com/Sitecore/Sitecore-Diagnostics-Tool/files/1638998/Copy.of.ECM.DiagToolset.Tests.xlsx)
